### PR TITLE
Use Python 3.6 from the deadsnakes ppa

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM ubuntu:14.04
 
 # Script to choose Python version
 COPY choose_python.sh /usr/bin/
-# Installer script for Pythons 2.7 3.4 3.5
+# Installer script for Pythons 2.7 3.4 3.5 3.6
 COPY build_install_pythons.sh /
 
-# Install Pythons 2.7 3.4 3.5 and matching pips
+# Install Pythons 2.7 3.4 3.5 3.6 and matching pips
 RUN bash build_install_pythons.sh && rm build_install_pythons.sh
 
 # Run Python selection on way into image

--- a/build_install_pythons.sh
+++ b/build_install_pythons.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install Pythons 2.7 3.4 3.5 and matching pips
+# Install Pythons 2.7 3.4 3.5 3.6 and matching pips
 set -e
 
 echo "deb http://ppa.launchpad.net/fkrull/deadsnakes/ubuntu trusty main" > /etc/apt/sources.list.d/deadsnakes.list
@@ -7,7 +7,7 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DB82666C
 apt-get update
 apt-get install -y wget
 wget https://bootstrap.pypa.io/get-pip.py
-for pyver in 3.4 3.5 2.6 2.7 3.3 ; do
+for pyver in 3.4 3.5 3.6 2.6 2.7 3.3 ; do
     pybin=python$pyver
     apt-get install -y ${pybin}-dev ${pybin}-tk
     ${pybin} get-pip.py
@@ -20,6 +20,7 @@ BUILD_PKGS="zlib1g-dev libbz2-dev libncurses5-dev libreadline-gplv2-dev \
     libsqlite3-dev libssl-dev libgdbm-dev tcl-dev tk-dev"
 apt-get -y install build-essential $BUILD_PKGS
 
+# currently unused
 function compile_python {
     local py_ver="$1"
     local extra_args="$2"
@@ -38,9 +39,6 @@ function compile_python {
 compile_python 2.7.11 "--enable-unicode=ucs2"
 # Get pip for narrow unicode Python
 /opt/cp27m/bin/python get-pip.py
-
-# Compile Python 3.6
-compile_python 3.6.0
 
 # Clean out not-needed packages
 apt-get -y remove $BUILD_PKGS

--- a/choose_python.sh
+++ b/choose_python.sh
@@ -6,8 +6,6 @@ uc_width=${UNICODE_WIDTH:-32}
 
 if [ "$py_ver" == "2.7" ] && [ "$uc_width" == "16" ]; then
     py_bin=/opt/cp27m/bin/python$py_ver
-elif [ "$py_ver" == "3.6" ]; then
-    py_bin=/opt/cp36m/bin/python$py_ver
 else
     py_bin=/usr/bin/python$py_ver
 fi


### PR DESCRIPTION
Using the deadsnakes 3.6 appears to have always been part of the plan.