### PR TITLE
Corrected link syntax

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,6 +12,6 @@ Ubuntu trusty (14.04) docker images (64-bit) with Pythons:
 installed via ``apt-get install python2.7-dev`` (etc).
 
 Pip installed for each Python via `get-pip.py
-<https://bootstrap.pypa.io/get-pip.py>_`.
+<https://bootstrap.pypa.io/get-pip.py>`_.
 
 Dockerhub builds this image automatically on push to Github.


### PR DESCRIPTION
https://github.com/matthew-brett/trusty/blob/64/README.rst vs https://github.com/radarhere/trusty/blob/link/README.rst