### PR TITLE
Moved Python compile cleanup into compile_python function

### DIFF
--- a/build_install_pythons.sh
+++ b/build_install_pythons.sh
@@ -41,6 +41,8 @@ function compile_python {
         && ./configure --prefix=$out_root ${extra_args} \
         && make \
         && make install)
+    # Remove stray files
+    rm -rf Python-${py_ver}
 }
 
 # Compile narrow unicode Python
@@ -71,4 +73,4 @@ apt-get -y autoremove
 apt-get clean
 
 # Remove stray files
-rm -rf Python-2.7* get-pip.py
+rm -f get-pip.py


### PR DESCRIPTION
I noticed that Python 3.7 cleanup wasn't happening in the same way as Python 2.7. Rather than adding it for this specific case, here is a general solution.