### PR TITLE
Updated comment

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,6 @@ installed via ``apt-get install python2.7-dev`` (etc).
 Pip installed for each Python via `get-pip.py
 <https://bootstrap.pypa.io/get-pip.py>`_.
 
-Pythons 3.7, 3.8rc1 are installed from source. They include pip and setuptools.
+Pythons 3.7, 3.8 are installed from source. They include pip and setuptools.
 
 Dockerhub builds this image automatically on push to Github.

--- a/build_install_pythons.sh
+++ b/build_install_pythons.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Install Pythons 2.7 3.4 3.5 3.6 3.7 3.8rc1 and matching pips
+# Install Pythons 2.7 3.4 3.5 3.6 3.7 3.8 and matching pips
 set -ex
 
 echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu trusty main" > /etc/apt/sources.list.d/deadsnakes.list


### PR DESCRIPTION
As of https://github.com/matthew-brett/trusty/commit/c6a009eedb557f4157e5428b4093133a4e99363d#diff-f36d243f9dd7dad91d339286d74fd515, it is no longer 3.8rc1, just 3.8