### PR TITLE
Updated URL for older pip

### DIFF
--- a/build_install_pythons.sh
+++ b/build_install_pythons.sh
@@ -17,7 +17,7 @@ for pyver in 3.4 3.5 3.6 2.7 2.6 3.3 ; do
     for badver in 2.6 3.3 3.4 3.5; do
         if [ "$pyver" == "$badver" ]; then
             get_pip_fname="get-pip-${pyver}.py"
-            wget $PIP_ROOT_URL/${pyver}/get-pip.py -O $get_pip_fname
+            wget $PIP_ROOT_URL/pip/${pyver}/get-pip.py -O $get_pip_fname
         fi
     done
     ${pybin} ${get_pip_fname}

--- a/build_install_pythons.sh
+++ b/build_install_pythons.sh
@@ -14,7 +14,7 @@ for pyver in 3.4 3.5 3.6 2.7 2.6 3.3 ; do
     get_pip_fname="get-pip.py"
     # Older Pythons need older versions of pip
     # These stored in URL directories named for the version.
-    for badver in 2.6 3.3 3.4; do
+    for badver in 2.6 3.3 3.4 3.5; do
         if [ "$pyver" == "$badver" ]; then
             get_pip_fname="get-pip-${pyver}.py"
             wget $PIP_ROOT_URL/${pyver}/get-pip.py -O $get_pip_fname


### PR DESCRIPTION
https://bootstrap.pypa.io/3.4/get-pip.py now gives a 404.
Looking at https://bootstrap.pypa.io/get-pip.py, it suggests https://bootstrap.pypa.io/pip/3.4/get-pip.py instead.

Also, https://bootstrap.pypa.io/get-pip.py now has a minimum version of 3.6, so I'm moving 3.5 into the list of old versions.